### PR TITLE
Lock down iptables binaries

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -118,6 +118,9 @@ RUN chmod +x /usr/local/bin/init-firewall.sh && \
   echo "$USERNAME ALL=(root) NOPASSWD: /usr/local/bin/init-firewall.sh" > /etc/sudoers.d/$USERNAME-firewall && \
   chmod 0440 /etc/sudoers.d/$USERNAME-firewall
 
+# Lock down iptables binaries to prevent tampering
+RUN chmod 700 /sbin/iptables /sbin/ip6tables
+
 # Switch back to user
 USER $USERNAME
 


### PR DESCRIPTION
## Summary
- Restrict access to iptables binaries to prevent tampering
- Enhance container security by preventing firewall rule modifications

## Changes
- Add `chmod 700` for /sbin/iptables and /sbin/ip6tables
- Ensure only root can access firewall management tools
- Add security comment explaining the purpose

## Test plan
- [ ] Verify iptables binaries have correct permissions (700)
- [ ] Ensure non-root user cannot access iptables
- [ ] Check that firewall still functions correctly
- [ ] Container builds successfully

Fixes #6

🤖 Generated with [Claude Code](https://claude.ai/code)